### PR TITLE
Fix ScrollBottom sometimes stuck page 

### DIFF
--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -103,14 +103,14 @@ let Actions = {
         (function(){
           let distance = window.scrollY,
               oldTimestamp = performance.now(),
-              maxScrollTimes = 10,
-              nowScrollTimes = 0;
+              scrolledTimes = 0;
           function step (newTimestamp) {
-            if (window.scrollY === 0) return;
+            if (window.scrollY === 0 || scrolledTimes >= 10) return;
+            newTimestamp = performance.now();
             window.scrollBy(0, -distance / (100 / (newTimestamp - oldTimestamp)));
-            nowScrollTimes = nowScrollTimes+1;
+            scrolledTimes +=1;
             oldTimestamp = newTimestamp;
-            if (nowScrollTimes < maxScrollTimes) window.requestAnimationFrame(step);
+            window.requestAnimationFrame(step);
           }
           window.requestAnimationFrame(step);
         })()
@@ -118,21 +118,20 @@ let Actions = {
       runAt: 'document_start'
     });
   },
-
   ScrollBottom: function () {
     chrome.tabs.executeScript(this.id, {
       code: `
         (function(){
           let distance = document.documentElement.scrollHeight - document.documentElement.clientHeight - window.scrollY,
               oldTimestamp = performance.now(),
-              maxScrollTimes = 10,
-              nowScrollTimes = 0;
+              scrolledTimes = 0;
           function step (newTimestamp) {
-            if (window.scrollY === document.documentElement.scrollHeight - document.documentElement.clientHeight) return;
+            if (Math.floor(window.scrollY+1) >= (document.documentElement.scrollHeight - document.documentElement.clientHeight) || scrolledTimes >= 10) return;
+            newTimestamp = performance.now();
             window.scrollBy(0, distance / (100 / (newTimestamp - oldTimestamp)));
-            nowScrollTimes = nowScrollTimes+1;
+            scrolledTimes +=1;
             oldTimestamp = newTimestamp;
-            if (nowScrollTimes < maxScrollTimes) window.requestAnimationFrame(step);
+            window.requestAnimationFrame(step);
           }
           window.requestAnimationFrame(step);
         })()

--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -103,12 +103,11 @@ let Actions = {
         (function(){
           let distance = window.scrollY,
               oldTimestamp = performance.now(),
-              scrolledTimes = 0;
+              maxTimestamp = oldTimestamp + 100*2;
           function step (newTimestamp) {
-            if (Math.floor(window.scrollY-1) <= 0 || scrolledTimes >= 20) return;
             newTimestamp = performance.now();
+            if (Math.floor(window.scrollY-1) <= 0 || newTimestamp >= maxTimestamp) return;
             window.scrollBy(0, -distance / (100 / (newTimestamp - oldTimestamp)));
-            scrolledTimes +=1;
             oldTimestamp = newTimestamp;
             window.requestAnimationFrame(step);
           }
@@ -125,12 +124,11 @@ let Actions = {
         (function(){
           let distance = document.documentElement.scrollHeight - document.documentElement.clientHeight - window.scrollY,
               oldTimestamp = performance.now(),
-              scrolledTimes = 0;
+              maxTimestamp = oldTimestamp + 100*2;
           function step (newTimestamp) {
-            if (Math.floor(window.scrollY+1) >= (document.documentElement.scrollHeight - document.documentElement.clientHeight) || scrolledTimes >= 20) return;
             newTimestamp = performance.now();
+            if (Math.floor(window.scrollY+1) >= (document.documentElement.scrollHeight - document.documentElement.clientHeight) || newTimestamp >= maxTimestamp) return;
             window.scrollBy(0, distance / (100 / (newTimestamp - oldTimestamp)));
-            scrolledTimes +=1;
             oldTimestamp = newTimestamp;
             window.requestAnimationFrame(step);
           }

--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -102,12 +102,15 @@ let Actions = {
       code: `
         (function(){
           let distance = window.scrollY,
-              oldTimestamp = performance.now();
+              oldTimestamp = performance.now(),
+              maxScrollTimes = 10,
+              nowScrollTimes = 0;
           function step (newTimestamp) {
             if (window.scrollY === 0) return;
             window.scrollBy(0, -distance / (100 / (newTimestamp - oldTimestamp)));
+            nowScrollTimes = nowScrollTimes+1;
             oldTimestamp = newTimestamp;
-            window.requestAnimationFrame(step);
+            if (nowScrollTimes < maxScrollTimes) window.requestAnimationFrame(step);
           }
           window.requestAnimationFrame(step);
         })()
@@ -121,12 +124,15 @@ let Actions = {
       code: `
         (function(){
           let distance = document.documentElement.scrollHeight - document.documentElement.clientHeight - window.scrollY,
-              oldTimestamp = performance.now();
+              oldTimestamp = performance.now(),
+              maxScrollTimes = 10,
+              nowScrollTimes = 0;
           function step (newTimestamp) {
             if (window.scrollY === document.documentElement.scrollHeight - document.documentElement.clientHeight) return;
             window.scrollBy(0, distance / (100 / (newTimestamp - oldTimestamp)));
+            nowScrollTimes = nowScrollTimes+1;
             oldTimestamp = newTimestamp;
-            window.requestAnimationFrame(step);
+            if (nowScrollTimes < maxScrollTimes) window.requestAnimationFrame(step);
           }
           window.requestAnimationFrame(step);
         })()

--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -104,9 +104,9 @@ let Actions = {
           let distance = window.scrollY,
               oldTimestamp = performance.now(),
               maxTimestamp = oldTimestamp + 100*2;
-          function step (newTimestamp) {
+          function step () {
             newTimestamp = performance.now();
-            if (Math.floor(window.scrollY-1) <= 0 || newTimestamp >= maxTimestamp) return;
+            if (Math.floor(window.scrollY) === 0 || newTimestamp >= maxTimestamp) return;
             window.scrollBy(0, -distance / (100 / (newTimestamp - oldTimestamp)));
             oldTimestamp = newTimestamp;
             window.requestAnimationFrame(step);
@@ -125,9 +125,9 @@ let Actions = {
           let distance = document.documentElement.scrollHeight - document.documentElement.clientHeight - window.scrollY,
               oldTimestamp = performance.now(),
               maxTimestamp = oldTimestamp + 100*2;
-          function step (newTimestamp) {
+          function step () {
             newTimestamp = performance.now();
-            if (Math.floor(window.scrollY+1) >= (document.documentElement.scrollHeight - document.documentElement.clientHeight) || newTimestamp >= maxTimestamp) return;
+            if (Math.ceil(window.scrollY) === (document.documentElement.scrollHeight - document.documentElement.clientHeight) || newTimestamp >= maxTimestamp) return;
             window.scrollBy(0, distance / (100 / (newTimestamp - oldTimestamp)));
             oldTimestamp = newTimestamp;
             window.requestAnimationFrame(step);

--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -105,7 +105,7 @@ let Actions = {
               oldTimestamp = performance.now(),
               scrolledTimes = 0;
           function step (newTimestamp) {
-            if (window.scrollY === 0 || scrolledTimes >= 10) return;
+            if (Math.floor(window.scrollY-1) <= 0 || scrolledTimes >= 20) return;
             newTimestamp = performance.now();
             window.scrollBy(0, -distance / (100 / (newTimestamp - oldTimestamp)));
             scrolledTimes +=1;
@@ -118,6 +118,7 @@ let Actions = {
       runAt: 'document_start'
     });
   },
+
   ScrollBottom: function () {
     chrome.tabs.executeScript(this.id, {
       code: `
@@ -126,7 +127,7 @@ let Actions = {
               oldTimestamp = performance.now(),
               scrolledTimes = 0;
           function step (newTimestamp) {
-            if (Math.floor(window.scrollY+1) >= (document.documentElement.scrollHeight - document.documentElement.clientHeight) || scrolledTimes >= 10) return;
+            if (Math.floor(window.scrollY+1) >= (document.documentElement.scrollHeight - document.documentElement.clientHeight) || scrolledTimes >= 20) return;
             newTimestamp = performance.now();
             window.scrollBy(0, distance / (100 / (newTimestamp - oldTimestamp)));
             scrolledTimes +=1;

--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -103,12 +103,11 @@ let Actions = {
         (function(){
           let distance = window.scrollY,
               oldTimestamp = performance.now(),
-              maxTimestamp = oldTimestamp + 100*2;
-          function step () {
-            newTimestamp = performance.now();
-            if (Math.floor(window.scrollY) === 0 || newTimestamp >= maxTimestamp) return;
-            window.scrollBy(0, -distance / (100 / (newTimestamp - oldTimestamp)));
+              maxTimestamp = oldTimestamp + 100;
+          function step (newTimestamp) {
+            window.scrollBy(0, -distance / 100 * (newTimestamp - oldTimestamp));
             oldTimestamp = newTimestamp;
+            if (Math.floor(window.scrollY) === 0 || newTimestamp > maxTimestamp) return;
             window.requestAnimationFrame(step);
           }
           window.requestAnimationFrame(step);
@@ -124,12 +123,11 @@ let Actions = {
         (function(){
           let distance = document.documentElement.scrollHeight - document.documentElement.clientHeight - window.scrollY,
               oldTimestamp = performance.now(),
-              maxTimestamp = oldTimestamp + 100*2;
-          function step () {
-            newTimestamp = performance.now();
-            if (Math.ceil(window.scrollY) === (document.documentElement.scrollHeight - document.documentElement.clientHeight) || newTimestamp >= maxTimestamp) return;
-            window.scrollBy(0, distance / (100 / (newTimestamp - oldTimestamp)));
+              maxTimestamp = oldTimestamp + 100;
+          function step (newTimestamp) {
+            window.scrollBy(0, distance / 100 * (newTimestamp - oldTimestamp));
             oldTimestamp = newTimestamp;
+            if (Math.ceil(window.scrollY) === (document.documentElement.scrollHeight - document.documentElement.clientHeight) || newTimestamp > maxTimestamp) return;
             window.requestAnimationFrame(step);
           }
           window.requestAnimationFrame(step);


### PR DESCRIPTION
this pull is going to solve a issue that ScrollBottom sometimes stuck page.

that bug is caused by the mismatch of window.scrollY and document.documentElement.scrollHeight-document.documentElement.clientHeight

since window.scrollY is float while backward two are integer
(and for some reason window.scrollY is seldom to be n.0, but i do not why)

i try to solve this issue by
1. make the judgments (of page position) tolerant. Not require accurately scroll to bottom and tolerate for about 1px.
2. add another truncation condition to prevent unexpected case, limit the max iterations 
3. add newTimestamp = performance.now(); to solve a small issue that sometimes newTimestamp is less than oldTimestamp at first iteration.

1 is only applied to ScrollBottom. because in my observation, ScrollTop does not have this issue.
2,3 are applied to both of ScrollBottom and ScrollTop to prevent unexpected case.

edit: 1 is apply to both of ScrollBottom and ScrollTop after 3rd commits
edit: the extra stopping condition is changed from max iterations to duration after 4th commits