### PR TITLE
make the middle mouse button default on Linux and MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ***
 
 **Please note:** Since Gesturefy is completely built upon the webxtensions API to offer a compatible addon for Firefox version 57, it is likewise limited to it. This means:
-- For MacOS & Linux users: The contextmenu is not suppressed on right-click [(see this bug)](https://bugzilla.mozilla.org/show_bug.cgi?id=1360278)
+- For MacOS & Linux users: The contextmenu is not suppressed on right-click [(see this bug)](https://bugzilla.mozilla.org/show_bug.cgi?id=1360278), thus middle mouse button is the default on these systems. The default will change once the issue is resolved.
 - The addon does not work on https://addons.mozilla.org [(for further information see this bug)](https://bugzilla.mozilla.org/show_bug.cgi?id=1310082), pure svg pages and internal pages like about:newtab, about:addons or other addon option pages.
 - The page must be partially loaded to perform gestures.
 

--- a/src/lib/background.js
+++ b/src/lib/background.js
@@ -11,6 +11,19 @@ chrome.storage.local.get(null, (storage) => {
   if (Object.keys(storage).length === 0) {
     // get data from local json and write it to the storage
     getJsonFileAsObject(chrome.runtime.getURL("res/config.json"), (config) => {
+      // The right mouse button is handled different on Linux and Mac,
+      // preventing gesturefy to work properly:
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1360278
+      //
+      // For now use the middle mouse button on these systems by default.
+      // TODO: Remove workaround once fixed upstream!
+      function LinuxMacWorkaround(info) {
+        if (info.os == "linux" || info.os == "mac")
+          config.Settings.Gesture.mouseButton = 4;
+      }
+      var PlatformInfo = browser.runtime.getPlatformInfo();
+      PlatformInfo.then(LinuxMacWorkaround);
+
       Config = config;
       saveData(config);
       // propagate config for tabs that were not able to load the config


### PR DESCRIPTION
The right mouse button is handled different on Linux and Mac,
preventing gesturefy to work properly:
https://bugzilla.mozilla.org/show_bug.cgi?id=1360278

For now use the middle mouse button on these systems by default.
TODO: Remove workaround once fixed upstream!