### PR TITLE
Add option to disable update notifications (fixes #156)

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -177,6 +177,11 @@
     "description": "center"
   },
 
+  "settingNameUpdateNotification": {
+    "message": "Display update notification",
+    "description": "Display update notification"
+  },
+
   "settingDescriptionMouseButton": {
     "message": "The mouse button which will trigger the gesture.",
     "description": "The mouse button which will trigger the gesture."
@@ -236,6 +241,10 @@
   "settingDescriptionDirectionsBackgroundOpacity": {
     "message": "Accepts any value in the range of 0 (invisible) and 1 (visible).",
     "description": "Accepts any value in the range of 0 (invisible) and 1 (visible)."
+  },
+  "settingDescriptionUpdateNotification": {
+    "message": "Show a notification when Gesturefy is updated.",
+    "description": "Show a notification when Gesturefy is updated."
   },
 
   "settingNameRemoveTabFocus": {

--- a/src/lib/background.js
+++ b/src/lib/background.js
@@ -140,28 +140,30 @@ chrome.runtime.onInstalled.addListener((details) => {
       });
     });
 
-    // get manifest for new version number
-    const manifest = chrome.runtime.getManifest();
+    if (!Config.Settings.General || Config.Settings.General.updateNotification) {
+      // get manifest for new version number
+      const manifest = chrome.runtime.getManifest();
 
-    // open changelog on notification click
-    chrome.notifications.onClicked.addListener(
-      function handleNotificationClick (id) {
-        if (id === "addonUpdate") {
-          chrome.tabs.create({
-            url: "https://github.com/Robbendebiene/Gesturefy/releases",
-            active: true
-          })
-          // remove the event listener
-          chrome.notifications.onClicked.removeListener(handleNotificationClick);
+      // open changelog on notification click
+      chrome.notifications.onClicked.addListener(
+        function handleNotificationClick (id) {
+          if (id === "addonUpdate") {
+            chrome.tabs.create({
+              url: "https://github.com/Robbendebiene/Gesturefy/releases",
+              active: true
+            })
+            // remove the event listener
+            chrome.notifications.onClicked.removeListener(handleNotificationClick);
+          }
         }
-      }
-    );
-    // create update notification
-    chrome.notifications.create("addonUpdate", {
-      "type": "basic",
-      "iconUrl": "../res/icons/iconx48.png",
-      "title": browser.i18n.getMessage('addonUpdateNotificationTitle', manifest.name),
-      "message": browser.i18n.getMessage('addonUpdateNotificationMessage', manifest.version)
-    });
+      );
+      // create update notification
+      chrome.notifications.create("addonUpdate", {
+        "type": "basic",
+        "iconUrl": "../res/icons/iconx48.png",
+        "title": browser.i18n.getMessage('addonUpdateNotificationTitle', manifest.name),
+        "message": browser.i18n.getMessage('addonUpdateNotificationMessage', manifest.version)
+      });
+    }
   }
 });

--- a/src/res/config.json
+++ b/src/res/config.json
@@ -128,6 +128,9 @@
       "mouseButton": 1,
       "wheelUp": "Previous",
       "wheelDown": "Next"
+    },
+    "General": {
+      "updateNotification": true
     }
   }
 }

--- a/src/ui/html/options.html
+++ b/src/ui/html/options.html
@@ -257,6 +257,15 @@
           </ul>
         </li>
       </ul>
+      <ul class="optionList">
+        <li>
+          <div>
+            <p data-i18n="settingNameUpdateNotification" class="option"></p>
+            <p data-i18n="settingDescriptionUpdateNotification" class="info"></p>
+          </div>
+          <input data-hierarchy="General" name="updateNotification" id="SettingUpdateNotification" class="toggleButton" type="checkbox"><label for="SettingUpdateNotification"></label>
+        </li>
+      </ul>
     </div>
 
     <div id="Gestures">


### PR DESCRIPTION
Added a new setting:
![2018-01-31-005633_753x701_scrot](https://user-images.githubusercontent.com/203361/35613764-cde782ac-0621-11e8-8dff-9d744b853d6b.png)

If the setting is disabled, this notification will not be shown when Gesturefy is updated:
![2018-01-31-005930_558x151_scrot](https://user-images.githubusercontent.com/203361/35613855-13bb6654-0622-11e8-90cf-b30ea89d7d98.png)

I wasn't sure how the translations work. Let me know if I need to do anything different.