### PR TITLE
Prevent 'Search text selection' from searching whitespace

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1083,6 +1083,10 @@
     "message": "Open empty tab",
     "description": "Open empty tab"
   },
+  "commandSettingLabelOpenEmptySearch": {
+    "message": "Open empty search",
+    "description": "Open empty search"
+  },
   "commandSettingLabelOpenEmptyWindow": {
     "message": "Open empty window",
     "description": "Open empty window"
@@ -1255,6 +1259,10 @@
   "commandSettingDescriptionOpenEmptyTab": {
     "message": "Determines if an empty tab should be opened if no URL or link was selected.",
     "description": "Determines if an empty tab should be opened if no URL or link was selected."
+  },
+  "commandSettingDescriptionOpenEmptySearch": {
+    "message": "Determines whether a search should be performed even if no text is present",
+    "description": "Determines whether a search should be performed even if no text is present"
   },
   "commandSettingDescriptionOpenEmptyWindow": {
     "message": "Determines if an empty window should be opened if no URL or link was selected.",

--- a/src/core/commands.js
+++ b/src/core/commands.js
@@ -1089,6 +1089,10 @@ export async function LinkToNewBookmark (sender, data) {
 
 
 export async function SearchTextSelection (sender, data) {
+  if (data.textSelection.trim() === "" && this.getSetting("openEmptySearch") === false) {
+    return;
+  }
+
   // use about:blank to prevent the display of the new tab page
   const tabProperties = {
     active: this.getSetting("focus"),
@@ -1138,6 +1142,10 @@ export async function SearchTextSelection (sender, data) {
 
 
 export async function SearchClipboard (sender, data) {
+  if (data.textSelection.trim() === "" && this.getSetting("openEmptySearch") === false) {
+    return;
+  }
+
   // use about:blank to prevent the display of the new tab page
   const tabProperties = {
     active: this.getSetting("focus"),
@@ -1786,7 +1794,7 @@ export async function PopupSearchEngines (sender, data) {
   channel.postMessage(dataset);
 
   channel.onMessage.addListener(async (message) => {
-    // check if primaray button was pressed
+    // check if primary button was pressed
     if (message.button === 0) {
       // focus new tab
       tabProperties.active = true;

--- a/src/resources/json/commands.json
+++ b/src/resources/json/commands.json
@@ -293,7 +293,8 @@
     "settings": {
       "position": "default",
       "focus": true,
-      "searchEngineURL": ""
+      "searchEngineURL": "",
+      "openEmptySearch": true
     },
     "permissions": ["search"],
     "group": "selection"
@@ -303,7 +304,8 @@
     "settings": {
       "position": "default",
       "focus": true,
-      "searchEngineURL": ""
+      "searchEngineURL": "",
+      "openEmptySearch": true
     },
     "permissions": ["search", "clipboardRead"],
     "group": "clipboard"

--- a/src/views/options/components/command-select/command-setting-templates.inc
+++ b/src/views/options/components/command-select/command-setting-templates.inc
@@ -52,6 +52,13 @@
   <p data-i18n="commandSettingDescriptionNewTabFocus" class="cb-setting-description"></p>
 </template>
 
+<template data-commands="SearchTextSelection SearchClipboard">
+  <span data-i18n="commandSettingLabelOpenEmptySearch" class="cb-setting-name"></span>
+  <input name="openEmptySearch" id="CommandSettingOpenEmptySearch" class="toggle-button" type="checkbox">
+  <label for="CommandSettingOpenEmptySearch"></label>
+  <p data-i18n="commandSettingDescriptionOpenEmptySearch" class="cb-setting-description"></p>
+</template>
+
 <template data-commands="CloseTab">
   <span data-i18n="commandSettingLabelTabNextFocus" class="cb-setting-name"></span>
   <p data-i18n="commandSettingDescriptionTabNextFocus" class="cb-setting-description"></p>


### PR DESCRIPTION
Hey, so this change is mostly in response to me sometimes accidentally triggering a 'search text selection' command without having any text selected. Right now it just opens the default search engine.

To me this seems like something that could be prevented, because why would anybody search for nothing? However, maybe there are users who use the behavior as it currently is, i'm not sure. Perhaps this could also be added as an option then.. Let me know what you think.

