### PR TITLE
Add fullscreen functionality

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -493,6 +493,10 @@
     "message": "New private window",
     "description": "New private window"
   },
+  "commandLabelFullscreen": {
+    "message": "Full screen",
+    "description": "Full screen"
+  },
   "commandLabelMoveTabToStart": {
     "message": "Move tab to start",
     "description": "Move tab to start"
@@ -841,6 +845,10 @@
   "commandDescriptionNewPrivateWindow": {
     "message": "Opens a new empty private window.",
     "description": "Opens a new empty private window."
+  },
+  "commandDescriptionFullscreen": {
+    "message": "Sets the window to its full size.",
+    "description": "Sets the window to its full size."
   },
   "commandDescriptionMoveTabToStart": {
     "message": "Moves the current tab to the start of the tab strip.",

--- a/src/core/commands.mjs
+++ b/src/core/commands.mjs
@@ -724,7 +724,7 @@ export async function ToggleWindowSize (sender, data) {
 export async function ToggleFullscreen (sender, data) {
   const window = await browser.windows.get(sender.tab.windowId);
   
-  browser.windows.update(sender.tab.windowId, {
+  await browser.windows.update(sender.tab.windowId, {
     state: window.state === 'fullscreen' ? 'maximized' : 'fullscreen'
   });
   // confirm success
@@ -735,7 +735,7 @@ export async function ToggleFullscreen (sender, data) {
 export async function Fullscreen (sender, data) {
   const window = await browser.windows.get(sender.tab.windowId);
   
-  browser.windows.update(sender.tab.windowId, {
+  await browser.windows.update(sender.tab.windowId, {
     state: 'fullscreen'
   });
   // confirm success

--- a/src/core/commands.mjs
+++ b/src/core/commands.mjs
@@ -723,9 +723,20 @@ export async function ToggleWindowSize (sender, data) {
 // maximizes the window if it is already in full screen mode
 export async function ToggleFullscreen (sender, data) {
   const window = await browser.windows.get(sender.tab.windowId);
-
-  await browser.windows.update(sender.tab.windowId, {
+  
+  browser.windows.update(sender.tab.windowId, {
     state: window.state === 'fullscreen' ? 'maximized' : 'fullscreen'
+  });
+  // confirm success
+  return true;
+}
+
+
+export async function Fullscreen (sender, data) {
+  const window = await browser.windows.get(sender.tab.windowId);
+  
+  browser.windows.update(sender.tab.windowId, {
+    state: 'fullscreen'
   });
   // confirm success
   return true;

--- a/src/resources/json/commands.json
+++ b/src/resources/json/commands.json
@@ -189,6 +189,10 @@
     "command": "NewPrivateWindow",
     "group": "window"
   },
+    {
+    "command": "Fullscreen",
+    "group": "window"
+  },
   {
     "command": "MoveTabToStart",
     "group": "move"


### PR DESCRIPTION
When you head to the _Gesturefy settings>Extras_ and set these settings up:

wheel gesture = 'On'
wheel gesture mouse button = 'right'
wheel up = 'Toggle full screen'
wheel down =  'Toggle full screen'

Afterwards whenever you hold down the right click and scroll up, you repeatedly toggle the full screen up and down because you usually scroll the wheel rather than rolling it just as much as a single upward movement. Thus you usually get back to the screen size that you were already using and the window size is not properly toggled yet. that can be solved if we have a single "Full Screen" option which sets the window to full screen. then we can set the _Gesturefy settings>Extras_ like this:

wheel gesture = 'On'
wheel gesture mouse button = 'right'
wheel up = 'full screen'
wheel down =  'Maximize window'

now you'll never face that problem ever again.

![After](https://user-images.githubusercontent.com/29219050/190888656-71c24006-c050-4892-b93d-478bdcd3fa5a.png)
![Before](https://user-images.githubusercontent.com/29219050/190888658-28adada4-5c13-4e88-99ef-bb129d77f2b7.png)