### PR TITLE
attach id to popup overlay fragment template

### DIFF
--- a/src/views/options/components/popup-box/main.mjs
+++ b/src/views/options/components/popup-box/main.mjs
@@ -122,6 +122,10 @@ class PopupBox extends HTMLElement {
    **/
   _buildPopupBox () {
     const template = document.createElement('template');
+
+    //attach id to identify the shadowRoot element container for gesturefy
+    template.setAttribute('id','gesturefyShadowRootContainer')
+
     template.innerHTML = `
       <div id="popupOverlay"></div>
       <div id="popupWrapper">


### PR DESCRIPTION
Hi @Robbendebiene 

I am submitting this pull request to facilitate an issue reported to JiffyReader extension referenced

https://addons.mozilla.org/en-US/firefox/addon/jiffy-reader/reviews/1873467/

It is helpful to clearly identy the elements that belong to gesturefy either by using a unique ID or unique class or unique attribute so that the JiffyReader parser can ignore your elements 
whenever they are injected dynamically.

Cheers from JiffyReader