### PR TITLE
Added the EnterFullscreen option

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -493,6 +493,10 @@
     "message": "New private window",
     "description": "New private window"
   },
+  "commandLabelEnterFullscreen": {
+    "message": "Enter full screen",
+    "description": "Enter full screen"
+  },
   "commandLabelMoveTabToStart": {
     "message": "Move tab to start",
     "description": "Move tab to start"
@@ -845,6 +849,10 @@
   "commandDescriptionNewPrivateWindow": {
     "message": "Opens a new empty private window.",
     "description": "Opens a new empty private window."
+  },
+  "commandDescriptionEnterFullscreen": {
+    "message": "Activates full screen mode for the current window.",
+    "description": "Activates full screen mode for the current window."
   },
   "commandDescriptionMoveTabToStart": {
     "message": "Moves the current tab to the start of the tab strip.",

--- a/src/core/commands.mjs
+++ b/src/core/commands.mjs
@@ -742,6 +742,19 @@ export async function ToggleFullscreen (sender, data) {
 }
 
 
+// Activates full screen mode for the current window if it is not already in full screen mode
+export async function EnterFullscreen (sender, data) {
+  const window = await browser.windows.get(sender.tab.windowId);
+  if (window.state !== 'fullscreen'){
+  await browser.windows.update(sender.tab.windowId, {
+    state: 'fullscreen'
+  });
+  // confirm success
+  return true;
+  }
+}
+
+
 export async function NewWindow (sender, data) {
   await browser.windows.create({});
   // confirm success

--- a/src/core/commands.mjs
+++ b/src/core/commands.mjs
@@ -745,12 +745,12 @@ export async function ToggleFullscreen (sender, data) {
 // Activates full screen mode for the current window if it is not already in full screen mode
 export async function EnterFullscreen (sender, data) {
   const window = await browser.windows.get(sender.tab.windowId);
-  if (window.state !== 'fullscreen'){
-  await browser.windows.update(sender.tab.windowId, {
-    state: 'fullscreen'
-  });
-  // confirm success
-  return true;
+  if (window.state !== 'fullscreen') {
+    await browser.windows.update(sender.tab.windowId, {
+      state: 'fullscreen'
+    });
+    // confirm success
+    return true;
   }
 }
 

--- a/src/resources/json/commands.json
+++ b/src/resources/json/commands.json
@@ -190,6 +190,10 @@
     "group": "window"
   },
   {
+    "command": "EnterFullscreen",
+    "group": "window.controls"
+  },
+  {
     "command": "MoveTabToStart",
     "group": "move"
   },


### PR DESCRIPTION
When you head to the Gesturefy settings>Extras and set these settings up:

wheel gesture = 'On'
wheel gesture mouse button = 'right'
wheel up = 'Toggle full screen'
wheel down = 'Toggle full screen'

Afterwards whenever you hold down the right click and scroll up, you repeatedly toggle the full screen up and down because you usually scroll the wheel rather than rolling it just as much as a single upward movement. Thus you usually get back to the screen size that you were already using and the window size is not properly toggled yet. that can be solved if we have a single "Full Screen" option which sets the window to full screen. then we can set the Gesturefy settings>Extras like this:

wheel gesture = 'On'
wheel gesture mouse button = 'right'
wheel up = 'full screen'
wheel down = 'Maximize window'

now you'll never face that problem ever again.

![190888658-28adada4-5c13-4e88-99ef-bb129d77f2b7](https://github.com/Robbendebiene/Gesturefy/assets/29219050/e37793f2-18c9-480f-a9c7-d6f60045160a)

![190888656-71c24006-c050-4892-b93d-478bdcd3fa5a](https://github.com/Robbendebiene/Gesturefy/assets/29219050/952f68d5-12ae-4b24-924e-635f042a1813)
